### PR TITLE
Fix confusing error about unknown city name when the DISTANCE is unknown.

### DIFF
--- a/src/Functions.php
+++ b/src/Functions.php
@@ -38,7 +38,15 @@ function calculateDistanceBetweenTowns($param)
     return calculateDistance($from, $to);
 }
 
-function calculateDistance($source, $dest)
+function isValidCityName($city, $knownCitiesList)
+{
+    foreach ($knownCitiesList as &$known) {
+        if ($city === $known) return true;
+    }
+    return false;
+}
+
+function calcDistance($source, $dest)
 {
     $w = 'Winterfell';
     $t = 'The Twins';
@@ -46,6 +54,16 @@ function calculateDistance($source, $dest)
     $q = 'Qarth';
     $d = 'Vaes Dothrak';
 
+    $arr = array($w, $t, $e, $q, $d);
+
+    if (!isValidCityName($source, $arr)) {
+        throw new \Exception("Unknown city: '{$source}'. Please check city name.");
+    }
+
+    if (!isValidCityName($dest, $arr)) {
+        throw new \Exception("Unknown city: '{$dest}'. Please check city name.");
+    }
+    
     if ($source === $w && $dest === $t || $source === $t && $dest === $w) {
         return 60;
     } elseif ($source === $t && $dest === $e || $source === $e && $dest === $t) {
@@ -54,5 +72,5 @@ function calculateDistance($source, $dest)
         return 125;
     }
 
-    throw new \Exception("Unknown cities: '{$source}' and {$dest}. Please check names");
+    throw new \Exception("Unknown distance between cities '{$source}' and '{$dest}'. Please ask for a distance between some other pair of cities.");
 }

--- a/src/Functions.php
+++ b/src/Functions.php
@@ -38,15 +38,7 @@ function calculateDistanceBetweenTowns($param)
     return calculateDistance($from, $to);
 }
 
-function isValidCityName($city, $knownCitiesList)
-{
-    foreach ($knownCitiesList as &$known) {
-        if ($city === $known) return true;
-    }
-    return false;
-}
-
-function calcDistance($source, $dest)
+function calculateDistance($source, $dest)
 {
     $w = 'Winterfell';
     $t = 'The Twins';
@@ -73,4 +65,12 @@ function calcDistance($source, $dest)
     }
 
     throw new \Exception("Unknown distance between cities '{$source}' and '{$dest}'. Please ask for a distance between some other pair of cities.");
+}
+
+function isValidCityName($city, $knownCitiesList)
+{
+    foreach ($knownCitiesList as &$known) {
+        if ($city === $known) return true;
+    }
+    return false;
 }

--- a/src/Functions.php
+++ b/src/Functions.php
@@ -46,13 +46,13 @@ function calculateDistance($source, $dest)
     $q = 'Qarth';
     $d = 'Vaes Dothrak';
 
-    $arr = array($w, $t, $e, $q, $d);
+    $knownCities = array($w, $t, $e, $q, $d);
 
-    if (!isValidCityName($source, $arr)) {
+    if (!isValidCityName($source, $knownCities)) {
         throw new \Exception("Unknown city: '{$source}'. Please check city name.");
     }
 
-    if (!isValidCityName($dest, $arr)) {
+    if (!isValidCityName($dest, $knownCities)) {
         throw new \Exception("Unknown city: '{$dest}'. Please check city name.");
     }
     
@@ -67,10 +67,10 @@ function calculateDistance($source, $dest)
     throw new \Exception("Unknown distance between cities '{$source}' and '{$dest}'. Please ask for a distance between some other pair of cities.");
 }
 
-function isValidCityName($city, $knownCitiesList)
+function isValidCityName($city, $knownCities)
 {
-    foreach ($knownCitiesList as &$known) {
-        if ($city === $known) return true;
+    foreach ($knownCities as &$knownCity) {
+        if ($city === $knownCity) return true;
     }
     return false;
 }


### PR DESCRIPTION
As it was, the `calculateDistance()` function throwed exception about 'unknown cities' having it failed to find the distance asked. It only looked amongst known distances between 3 certain city pairs. And yet it knows 5 different cities, which suggests 10 possible pairs of known cities. In case a student passed valid city names not in the 3 lucky pairs, she got the 'unknown cities' error and not an 'unknown distance'. With correct city names it might be a bit confusing, and the mistake of passing `'Winterfell'` & `'The Eyrie'` instead of lesson-required `'Winterfell'` & `'The Twins'` is quite possible.

Thus, the separate city name validation is introduced. Since it is needed twice it is made a function `isValidCityName()`. Being a different function it does not know the city-name-holding variables `$w`, `$q` etc. Thus, the valid names are passed to it as an array, with `foreach` looping until it finds any match. The code is tested in PHP Repl.it.

The different quotes usage for `'{$source}' and {$dest}` gone in the process.