### PR TITLE
improve tests

### DIFF
--- a/modules/10-basics/40-instructions/Test.php
+++ b/modules/10-basics/40-instructions/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\Basics\Instructions;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/10-basics/45-testing/Test.php
+++ b/modules/10-basics/45-testing/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\Basics\Testing;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/10-basics/50-syntax-errors/Test.php
+++ b/modules/10-basics/50-syntax-errors/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\Basics\SyntaxErrors;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/20-arithmetics/20-basic/Test.php
+++ b/modules/20-arithmetics/20-basic/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\Arithmetics\Basics;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/20-arithmetics/25-operator/Test.php
+++ b/modules/20-arithmetics/25-operator/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\Arithmetics\Operator;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/20-arithmetics/27-commutativity/Test.php
+++ b/modules/20-arithmetics/27-commutativity/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\Arithmetics\Commutativity;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/20-arithmetics/30-composition/Test.php
+++ b/modules/20-arithmetics/30-composition/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\Arithmetics\Composition;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/20-arithmetics/40-priority/Test.php
+++ b/modules/20-arithmetics/40-priority/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\Arithmetics\Priority;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/20-arithmetics/45-linting/Test.php
+++ b/modules/20-arithmetics/45-linting/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\Arithmetics\Linting;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/25-strings/10-quotes/Test.php
+++ b/modules/25-strings/10-quotes/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\Strings\Quotes;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/25-strings/15-escape-characters/Test.php
+++ b/modules/25-strings/15-escape-characters/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\Arithmetics\EscapeCharacters;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/25-strings/20-concatenation/Test.php
+++ b/modules/25-strings/20-concatenation/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\Strings\Concatenation;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/25-strings/30-encoding/Test.php
+++ b/modules/25-strings/30-encoding/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\Strings\Encoding;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/27-data-types/40-primitive-data-types/Test.php
+++ b/modules/27-data-types/40-primitive-data-types/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\DataTypes\PrimitiveDataTypes;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/27-data-types/50-weak-typing/Test.php
+++ b/modules/27-data-types/50-weak-typing/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\DataTypes\WeakTyping;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/27-data-types/55-type-conversion/Test.php
+++ b/modules/27-data-types/55-type-conversion/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\DataTypes\TypeConversion;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/30-variables/10-definition/Test.php
+++ b/modules/30-variables/10-definition/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\Variables\Definition;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/30-variables/12-change/Test.php
+++ b/modules/30-variables/12-change/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\Variables\Change;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/30-variables/13-naming/Test.php
+++ b/modules/30-variables/13-naming/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\Variables\Naming;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/30-variables/14-errors/Test.php
+++ b/modules/30-variables/14-errors/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\Variables\Errors;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/30-variables/15-expressions/Test.php
+++ b/modules/30-variables/15-expressions/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\Variables\Expressions;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/30-variables/18-concatenation/Test.php
+++ b/modules/30-variables/18-concatenation/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\Variables\Concatenation;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/30-variables/19-naming-style/Test.php
+++ b/modules/30-variables/19-naming-style/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\Variables\Naming;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/30-variables/20-magic-numbers/Test.php
+++ b/modules/30-variables/20-magic-numbers/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\Variables\MagicNumbers;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/30-variables/24-magic-constants/Test.php
+++ b/modules/30-variables/24-magic-constants/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/30-variables/25-interpolation/Test.php
+++ b/modules/30-variables/25-interpolation/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\Variables\Interpolation;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/30-variables/30-symbols/Test.php
+++ b/modules/30-variables/30-symbols/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\Variables\Symbols;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/30-variables/35-heredoc/Test.php
+++ b/modules/30-variables/35-heredoc/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\Variables\Heredoc;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/35-calling-functions/100-call/Test.php
+++ b/modules/35-calling-functions/100-call/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\CallingFunctions\Call;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/35-calling-functions/120-function-signature/Test.php
+++ b/modules/35-calling-functions/120-function-signature/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\CallingFunctions\FunctionSignature;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/35-calling-functions/130-stdlib/Test.php
+++ b/modules/35-calling-functions/130-stdlib/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\CallingFunctions\Stdlib;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/35-calling-functions/135-default-arguments/Test.php
+++ b/modules/35-calling-functions/135-default-arguments/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\CallingFunctions\DefaultArguments;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/35-calling-functions/140-variadic-arguments/Test.php
+++ b/modules/35-calling-functions/140-variadic-arguments/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\CallingFunctions\Call;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/35-calling-functions/150-expression/Test.php
+++ b/modules/35-calling-functions/150-expression/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\CallingFunctions\Expression;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/35-calling-functions/200-arguments-as-expressions/Test.php
+++ b/modules/35-calling-functions/200-arguments-as-expressions/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\CallingFunctions\ArgumentsAsExpressions;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/35-calling-functions/250-functions-as-arguments/Test.php
+++ b/modules/35-calling-functions/250-functions-as-arguments/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\CallingFunctions\FunctionsAsArguments;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/35-calling-functions/270-deterministic/Test.php
+++ b/modules/35-calling-functions/270-deterministic/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\CallingFunctions\Call;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {

--- a/modules/35-calling-functions/300-side-effects/Test.php
+++ b/modules/35-calling-functions/300-side-effects/Test.php
@@ -1,8 +1,10 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects
 
 namespace HexletBasics\CallingFunctions\SideEffects;
 
 use PHPUnit\Framework\TestCase;
+
+\HexletBasics\Functions\runScript();
 
 class Test extends TestCase
 {


### PR DESCRIPTION
Добавил вызов `runScript()` в тесты всех упражнений где `print_r()` в решении находится определения функций.
Это все упражнения модулей: 10-basics, 20-arithmetics, 25-strings, 27-data-types, 30-variables, 35-calling-functions.