### PR TITLE
fix link to date formats examples

### DIFF
--- a/modules/70-dates/20-date/description.ru.yml
+++ b/modules/70-dates/20-date/description.ru.yml
@@ -44,6 +44,6 @@ instructions: |
 
 tips:
   - |
-    [Примеры форматов дат](https://php.net/manual/ru/datetime.formats.date.php)
+    [Примеры форматов дат](https://www.php.net/manual/ru/datetime.format.php)
 
 definitions: []


### PR DESCRIPTION
Заменил ссылку на форматы даты для функции `date()` на правильную.

#274