### PR TITLE
Update Test.php

### DIFF
--- a/modules/10-basics/10-hello-world/Test.php
+++ b/modules/10-basics/10-hello-world/Test.php
@@ -4,8 +4,6 @@ namespace HexletBasics\Basics\HelloWorld;
 
 use PHPUnit\Framework\TestCase;
 
-\HexletBasics\Functions\runScript();
-
 class Test extends TestCase
 {
     public function test()
@@ -13,5 +11,10 @@ class Test extends TestCase
         $expected = 'Hello, World!';
         $this->expectOutputString($expected);
         require 'index.php';
+    }
+
+    public function setUp(): void
+    {
+        \HexletBasics\Functions\runScript();
     }
 }


### PR DESCRIPTION
Предоставленный вами код является тестовым примером PHPUnit. Он проверяет выходные данные index.php скрипта и ожидает, что он выведет строку "Привет, мир!".

Однако существует проблема со строкой:

\HexletBasics\Functions\runScript();

Эта строка пытается вызвать функцию с именем runScript() из HexletBasics\Functions пространства имен, но она находится за пределами какой-либо функции или метода и, следовательно, вызовет синтаксическую ошибку.

Если вы хотели вызвать runScript() перед запуском тестового примера, вам следует переместить эту строку в функцию или метод в вашем тестовом примере. Если вы вообще не собирались вызывать эту функцию, вы можете просто удалить эту строку.