### PR TITLE
fix: prevent double https in normalizeUrl

### DIFF
--- a/modules/48-conditionals/40-if-else/index.php
+++ b/modules/48-conditionals/40-if-else/index.php
@@ -5,6 +5,10 @@ namespace HexletBasics\Conditionals\IfElse;
 // BEGIN
 function normalizeUrl($url)
 {
+    if (strpos($url, 'https://') === 0) {
+        return $url;
+    }
+
     if (strpos($url, 'http://') === 0) {
         $domain = substr($url, 7);
     } else {
@@ -13,4 +17,5 @@ function normalizeUrl($url)
 
     return "https://{$domain}";
 }
+
 // END


### PR DESCRIPTION
Добавил проверку на случай, когда входной URL уже начинается с "https://"