### PR TITLE
chore: add dependabot config for monthly dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      composer:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds `.github/dependabot.yml` to enable monthly automated dependency updates grouped by ecosystem.

Each ecosystem gets its own grouped PR from Dependabot (one for `github-actions`, one for language packages).